### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A complete 2048 game implementation with client-server architecture, OAuth2 auth
 
 - **Victory Condition**: Game ends when two 8192 tiles merge
 - **Mobile Compatible**: Responsive design with touch support
+- **Dark Mode**: Optional dark theme toggle
 - **Real-time Communication**: WebSocket-based client-server communication
 - **Authentication**: OAuth2 integration for user login
 - **Leaderboards**: Daily, weekly, monthly, and all-time rankings

--- a/backend/cmd/server/static/css/dark.css
+++ b/backend/cmd/server/static/css/dark.css
@@ -1,0 +1,38 @@
+/* Dark mode overrides */
+body.dark-mode {
+    background: #1e1e1e;
+    color: #f3f3f3;
+}
+
+body.dark-mode .game-title,
+body.dark-mode .score-label,
+body.dark-mode .score-value,
+body.dark-mode .user-name {
+    color: #f3f3f3;
+}
+
+body.dark-mode .instructions,
+body.dark-mode .connection-status {
+    background: #333;
+    color: #f3f3f3;
+}
+
+body.dark-mode .score-box,
+body.dark-mode .new-game-btn,
+body.dark-mode .logout-btn,
+body.dark-mode .overlay-btn,
+body.dark-mode .theme-toggle-btn {
+    background: #555;
+    color: #f3f3f3;
+}
+
+body.dark-mode .new-game-btn:hover,
+body.dark-mode .logout-btn:hover,
+body.dark-mode .overlay-btn:hover,
+body.dark-mode .theme-toggle-btn:hover {
+    background: #777;
+}
+
+body.dark-mode .leaderboard-entry {
+    background: #444;
+}

--- a/backend/cmd/server/static/js/theme.js
+++ b/backend/cmd/server/static/js/theme.js
@@ -1,0 +1,34 @@
+class ThemeToggle {
+    constructor() {
+        this.btn = document.getElementById('theme-toggle');
+        if (!this.btn) return;
+        this.applySaved();
+        this.btn.addEventListener('click', () => this.toggle());
+    }
+
+    applySaved() {
+        const saved = localStorage.getItem('theme');
+        if (saved === 'dark') {
+            document.body.classList.add('dark-mode');
+            this.btn.textContent = 'Light Mode';
+        } else {
+            this.btn.textContent = 'Dark Mode';
+        }
+    }
+
+    toggle() {
+        if (document.body.classList.contains('dark-mode')) {
+            document.body.classList.remove('dark-mode');
+            localStorage.setItem('theme', 'light');
+            this.btn.textContent = 'Dark Mode';
+        } else {
+            document.body.classList.add('dark-mode');
+            localStorage.setItem('theme', 'dark');
+            this.btn.textContent = 'Light Mode';
+        }
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    window.themeToggle = new ThemeToggle();
+});

--- a/backend/cmd/server/templates/game.html
+++ b/backend/cmd/server/templates/game.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{.title}}</title>
     <link rel="stylesheet" href="{{static "/css/main.css"}}">
+    <link rel="stylesheet" href="{{static "/css/dark.css"}}">
     <link rel="stylesheet" href="{{static "/css/mobile.css"}}">
 
     <meta name="theme-color" content="#faf8ef">
@@ -25,6 +26,7 @@
                     {{end}}
                     <span class="user-name">{{.user.Name}}</span>
                     <button class="logout-btn" onclick="logout()">Logout</button>
+                    <button class="theme-toggle-btn" id="theme-toggle">Dark Mode</button>
                 </div>
             </div>
         </header>
@@ -80,6 +82,7 @@
 <script src="{{static "/js/websocket.js"}}"></script>
 <script src="{{static "/js/canvas-game.js"}}"></script>
 <script src="{{static "/js/auth.js"}}"></script>
+<script src="{{static "/js/theme.js"}}"></script>
 <script>
     // Initialize Canvas Game
     document.addEventListener('DOMContentLoaded', function() {
@@ -188,6 +191,22 @@
 }
 
 .logout-btn:hover {
+    background: #776e65;
+}
+
+.theme-toggle-btn {
+    background: #8f7a66;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background 0.2s ease;
+    margin-left: 8px;
+}
+
+.theme-toggle-btn:hover {
     background: #776e65;
 }
 
@@ -398,6 +417,13 @@
         padding: 6px 12px;
         font-size: 0.8rem;
         border-radius: 4px;
+    }
+
+    .theme-toggle-btn {
+        padding: 6px 12px;
+        font-size: 0.8rem;
+        border-radius: 4px;
+        margin-left: 8px;
     }
 
     .game-info {


### PR DESCRIPTION
## Summary
- add dark-mode styles and theme toggle script
- include new script and stylesheet in game page
- expose dark mode option in README

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6842e0459428832cbbb2b0aa32abc35a